### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mysql1
-version: 0.17.0
+version: 0.17.0+1
 description: A library for connecting to and querying MySQL & MariaDB databases.
 homepage: https://github.com/adamlofts/mysql1_dart
 

--- a/test/integration/one_test.dart
+++ b/test/integration/one_test.dart
@@ -175,15 +175,15 @@ void main() {
   initializeTest(
       "test1",
       "create table test1 ("
-      "atinyint tinyint, asmallint smallint, amediumint mediumint, abigint bigint, aint int, "
-      "adecimal decimal(20,10), afloat float, adouble double, areal real, "
-      "aboolean boolean, abit bit(20), aserial serial, "
-      "adate date, adatetime datetime, atimestamp timestamp, atime time, ayear year, "
-      "achar char(10), avarchar varchar(10), "
-      "atinytext tinytext, atext text, amediumtext mediumtext, alongtext longtext, "
-      "abinary binary(10), avarbinary varbinary(10), "
-      "atinyblob tinyblob, amediumblob mediumblob, ablob blob, alongblob longblob, "
-      "aenum enum('a', 'b', 'c'), aset set('a', 'b', 'c'), ageometry geometry)");
+          "atinyint tinyint, asmallint smallint, amediumint mediumint, abigint bigint, aint int, "
+          "adecimal decimal(20,10), afloat float, adouble double, areal real, "
+          "aboolean boolean, abit bit(20), aserial serial, "
+          "adate date, adatetime datetime, atimestamp timestamp, atime time, ayear year, "
+          "achar char(10), avarchar varchar(10), "
+          "atinytext tinytext, atext text, amediumtext mediumtext, alongtext longtext, "
+          "abinary binary(10), avarbinary varbinary(10), "
+          "atinyblob tinyblob, amediumblob mediumblob, ablob blob, alongblob longblob, "
+          "aenum enum('a', 'b', 'c'), aset set('a', 'b', 'c'), ageometry geometry)");
 
   test('show tables', () async {
     var results = await conn.query("show tables");

--- a/test/unit/buffered_socket_test.dart
+++ b/test/unit/buffered_socket_test.dart
@@ -4,6 +4,7 @@ library buffered_socket_test;
 
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -22,13 +23,13 @@ class MockSocket extends StreamView<RawSocketEvent> implements RawSocket {
   List<int> _data;
   int available() => _data.length;
 
-  List<int> read([int len]) {
+  Uint8List read([int len]) {
     var count = len;
     if (count > _data.length) {
       count = _data.length;
     }
     var data = _data.getRange(0, count);
-    var list = new List<int>();
+    var list = new Uint8List(data.length);
     list.addAll(data);
     _data.removeRange(0, count);
     return list;

--- a/test/unit/buffered_socket_test.dart
+++ b/test/unit/buffered_socket_test.dart
@@ -30,7 +30,7 @@ class MockSocket extends StreamView<RawSocketEvent> implements RawSocket {
     }
     var data = _data.getRange(0, count);
     var list = new Uint8List(data.length);
-    list.addAll(data);
+    list.setRange(0, data.length, data);
     _data.removeRange(0, count);
     return list;
   }


### PR DESCRIPTION
`RawSocket.read()` is being updated in the Dart SDK to
declare a return type of `Uint8List` rather than `List<int>`.
This forwards-compatible change prepares for that change
in the SDK.

https://github.com/dart-lang/sdk/issues/36900