### PR TITLE
Added caching_sha2_password support for mysql1

### DIFF
--- a/lib/src/auth/auth_handler.dart
+++ b/lib/src/auth/auth_handler.dart
@@ -10,9 +10,13 @@ import '../buffer.dart';
 import '../handlers/handler.dart';
 
 class AuthHandler extends Handler {
+  static const MYSQL_NATIVE_PASSWORD = 'mysql_native_password';
+  static const CACHING_SHA2_PASSWORD = "caching_sha2_password";
+
   final String? username;
   final String? password;
   final String? db;
+  final String? plugin;
   final List<int> scrambleBuffer;
   final int clientFlags;
   final int maxPacketSize;
@@ -20,7 +24,7 @@ class AuthHandler extends Handler {
 //  final bool _ssl;
 
   AuthHandler(this.username, this.password, this.db, this.scrambleBuffer,
-      this.clientFlags, this.maxPacketSize, this.characterSet,
+      this.clientFlags, this.maxPacketSize, this.characterSet, this.plugin,
       {bool ssl = false})
       : /*this._ssl = false,*/
         super(Logger('AuthHandler'));
@@ -30,15 +34,23 @@ class AuthHandler extends Handler {
     if (password == null) {
       hash = <int>[];
     } else {
-      final hashedPassword = sha1.convert(utf8.encode(password!)).bytes;
-      final doubleHashedPassword = sha1.convert(hashedPassword).bytes;
+      if (plugin == MYSQL_NATIVE_PASSWORD) {
+        final hashedPassword = sha1.convert(utf8.encode(password!)).bytes;
+        final doubleHashedPassword = sha1.convert(hashedPassword).bytes;
 
-      final bytes = List<int>.from(scrambleBuffer)
-        ..addAll(doubleHashedPassword);
-      final hashedSaltedPassword = sha1.convert(bytes).bytes;
+        final bytes = List<int>.from(scrambleBuffer)
+          ..addAll(doubleHashedPassword);
+        final hashedSaltedPassword = sha1.convert(bytes).bytes;
 
-      hash = List<int>.generate(hashedSaltedPassword.length,
-          (index) => hashedSaltedPassword[index] ^ hashedPassword[index]);
+        hash = List<int>.generate(hashedSaltedPassword.length,
+            (index) => hashedSaltedPassword[index] ^ hashedPassword[index]);
+      } else {
+        final List<int> shaPwd = sha256.convert(utf8.encode(password!)).bytes;
+        final List<int> shaShaPwd = sha256.convert(shaPwd).bytes;
+        hash =
+            sha256.convert(List.from(shaShaPwd)..addAll(scrambleBuffer)).bytes;
+        for (int i = 0; i < hash.length; i++) hash[i] ^= shaPwd[i];
+      }
     }
     return hash;
   }

--- a/lib/src/auth/auth_handler.dart
+++ b/lib/src/auth/auth_handler.dart
@@ -10,9 +10,6 @@ import '../buffer.dart';
 import '../handlers/handler.dart';
 
 class AuthHandler extends Handler {
-  static const MYSQL_NATIVE_PASSWORD = 'mysql_native_password';
-  static const CACHING_SHA2_PASSWORD = "caching_sha2_password";
-
   final String? username;
   final String? password;
   final String? db;
@@ -45,11 +42,13 @@ class AuthHandler extends Handler {
         hash = List<int>.generate(hashedSaltedPassword.length,
             (index) => hashedSaltedPassword[index] ^ hashedPassword[index]);
       } else {
-        final List<int> shaPwd = sha256.convert(utf8.encode(password!)).bytes;
-        final List<int> shaShaPwd = sha256.convert(shaPwd).bytes;
+        final shaPwd = sha256.convert(utf8.encode(password!)).bytes;
+        final shaShaPwd = sha256.convert(shaPwd).bytes;
         hash =
             sha256.convert(List.from(shaShaPwd)..addAll(scrambleBuffer)).bytes;
-        for (int i = 0; i < hash.length; i++) hash[i] ^= shaPwd[i];
+        for (var i = 0; i < hash.length; i++) {
+          hash[i] ^= shaPwd[i];
+        }
       }
     }
     return hash;

--- a/lib/src/auth/auth_handler.dart
+++ b/lib/src/auth/auth_handler.dart
@@ -21,8 +21,8 @@ class AuthHandler extends Handler {
 //  final bool _ssl;
 
   AuthHandler(this.username, this.password, this.db, this.scrambleBuffer,
-      this.clientFlags, this.maxPacketSize, this.characterSet, this.plugin,
-      {bool ssl = false})
+      this.clientFlags, this.maxPacketSize, this.characterSet,
+      {this.plugin, bool ssl = false})
       : /*this._ssl = false,*/
         super(Logger('AuthHandler'));
 

--- a/lib/src/auth/handshake_handler.dart
+++ b/lib/src/auth/handshake_handler.dart
@@ -26,7 +26,7 @@ class HandshakeHandler extends Handler {
   int? serverLanguage;
   int? serverStatus;
   int? scrambleLength;
-  late String pluginName;
+  String? pluginName;
   bool useCompression = false;
   bool useSSL = false;
 
@@ -80,8 +80,8 @@ class HandshakeHandler extends Handler {
 
       if (serverCapabilities & CLIENT_PLUGIN_AUTH > 0) {
         pluginName = response.readStringToEnd();
-        if (pluginName.codeUnitAt(pluginName.length - 1) == 0) {
-          pluginName = pluginName.substring(0, pluginName.length - 1);
+        if (pluginName!.codeUnitAt(pluginName!.length - 1) == 0) {
+          pluginName = pluginName!.substring(0, pluginName!.length - 1);
         }
       }
     }

--- a/lib/src/auth/handshake_handler.dart
+++ b/lib/src/auth/handshake_handler.dart
@@ -148,12 +148,13 @@ class HandshakeHandler extends Handler {
                 clientFlags,
                 _maxPacketSize,
                 _characterSet,
-                pluginName,
+                plugin: pluginName,
               )));
     }
 
     return HandlerResponse(
         nextHandler: AuthHandler(_user, _password, _db, scrambleBuffer,
-            clientFlags, _maxPacketSize, _characterSet, pluginName));
+            clientFlags, _maxPacketSize, _characterSet,
+            plugin: pluginName));
   }
 }

--- a/lib/src/auth/handshake_handler.dart
+++ b/lib/src/auth/handshake_handler.dart
@@ -12,8 +12,6 @@ import 'ssl_handler.dart';
 import 'auth_handler.dart';
 
 class HandshakeHandler extends Handler {
-  static const String MYSQL_NATIVE_PASSWORD = 'mysql_native_password';
-
   final String? _user;
   final String? _password;
   final String? _db;
@@ -109,7 +107,8 @@ class HandshakeHandler extends Handler {
     }
 
     if ((serverCapabilities & CLIENT_PLUGIN_AUTH) != 0 &&
-        pluginName != MYSQL_NATIVE_PASSWORD) {
+        !(pluginName == MYSQL_NATIVE_PASSWORD ||
+            pluginName == CACHING_SHA2_PASSWORD)) {
       throw MySqlClientError(
           'Authentication plugin not supported: $pluginName');
     }
@@ -149,11 +148,12 @@ class HandshakeHandler extends Handler {
                 clientFlags,
                 _maxPacketSize,
                 _characterSet,
+                pluginName,
               )));
     }
 
     return HandlerResponse(
         nextHandler: AuthHandler(_user, _password, _db, scrambleBuffer,
-            clientFlags, _maxPacketSize, _characterSet));
+            clientFlags, _maxPacketSize, _characterSet, pluginName));
   }
 }

--- a/lib/src/handlers/handler.dart
+++ b/lib/src/handlers/handler.dart
@@ -8,6 +8,9 @@ import '../mysql_exception.dart';
 import '../prepared_statements/prepare_ok_packet.dart';
 import 'ok_packet.dart';
 
+const String MYSQL_NATIVE_PASSWORD = 'mysql_native_password';
+const String CACHING_SHA2_PASSWORD = "caching_sha2_password";
+
 class _NoResult {
   const _NoResult();
 }

--- a/lib/src/handlers/handler.dart
+++ b/lib/src/handlers/handler.dart
@@ -9,7 +9,7 @@ import '../prepared_statements/prepare_ok_packet.dart';
 import 'ok_packet.dart';
 
 const String MYSQL_NATIVE_PASSWORD = 'mysql_native_password';
-const String CACHING_SHA2_PASSWORD = "caching_sha2_password";
+const String CACHING_SHA2_PASSWORD = 'caching_sha2_password';
 
 class _NoResult {
   const _NoResult();

--- a/test/unit/auth_handler_test.dart
+++ b/test/unit/auth_handler_test.dart
@@ -2,15 +2,14 @@ library mysql1.auth_handler_test;
 
 import 'package:mysql1/src/auth/auth_handler.dart';
 import 'package:mysql1/src/constants.dart';
-import 'package:mysql1/src/handlers/handler.dart';
 
 import 'package:test/test.dart';
 
 void main() {
   group('auth_handler:', () {
     test('hash password correctly', () {
-      var handler = AuthHandler('username', 'password', 'db', [1, 2, 3, 4], 0,
-          100, 0, MYSQL_NATIVE_PASSWORD);
+      var handler =
+          AuthHandler('username', 'password', 'db', [1, 2, 3, 4], 0, 100, 0);
 
       var hash = handler.getHash();
 
@@ -47,7 +46,7 @@ void main() {
       var username = 'Boris';
       var password = 'Password';
       var handler = AuthHandler(username, password, null, [1, 2, 3, 4],
-          clientFlags, maxPacketSize, characterSet, MYSQL_NATIVE_PASSWORD);
+          clientFlags, maxPacketSize, characterSet);
 
       var hash = handler.getHash();
       var buffer = handler.createRequest();
@@ -77,8 +76,7 @@ void main() {
           [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
           clientFlags,
           maxPacketSize,
-          characterSet,
-          MYSQL_NATIVE_PASSWORD);
+          characterSet);
 
       var hash = handler.getHash();
       var buffer = handler.createRequest();
@@ -100,8 +98,8 @@ void main() {
     var username = 'Борис';
     var password = 'здрасти';
     var database = 'дтабасе';
-    var handler = AuthHandler(username, password, database, [1, 2, 3, 4], 0,
-        100, 0, MYSQL_NATIVE_PASSWORD);
+    var handler =
+        AuthHandler(username, password, database, [1, 2, 3, 4], 0, 100, 0);
 
     var hash = handler.getHash();
     var buffer = handler.createRequest();

--- a/test/unit/auth_handler_test.dart
+++ b/test/unit/auth_handler_test.dart
@@ -2,14 +2,15 @@ library mysql1.auth_handler_test;
 
 import 'package:mysql1/src/auth/auth_handler.dart';
 import 'package:mysql1/src/constants.dart';
+import 'package:mysql1/src/handlers/handler.dart';
 
 import 'package:test/test.dart';
 
 void main() {
   group('auth_handler:', () {
     test('hash password correctly', () {
-      var handler =
-          AuthHandler('username', 'password', 'db', [1, 2, 3, 4], 0, 100, 0);
+      var handler = AuthHandler('username', 'password', 'db', [1, 2, 3, 4], 0,
+          100, 0, MYSQL_NATIVE_PASSWORD);
 
       var hash = handler.getHash();
 
@@ -46,7 +47,7 @@ void main() {
       var username = 'Boris';
       var password = 'Password';
       var handler = AuthHandler(username, password, null, [1, 2, 3, 4],
-          clientFlags, maxPacketSize, characterSet);
+          clientFlags, maxPacketSize, characterSet, null);
 
       var hash = handler.getHash();
       var buffer = handler.createRequest();
@@ -76,7 +77,8 @@ void main() {
           [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
           clientFlags,
           maxPacketSize,
-          characterSet);
+          characterSet,
+          'mysql_native_password');
 
       var hash = handler.getHash();
       var buffer = handler.createRequest();
@@ -98,8 +100,8 @@ void main() {
     var username = 'Борис';
     var password = 'здрасти';
     var database = 'дтабасе';
-    var handler =
-        AuthHandler(username, password, database, [1, 2, 3, 4], 0, 100, 0);
+    var handler = AuthHandler(username, password, database, [1, 2, 3, 4], 0,
+        100, 0, MYSQL_NATIVE_PASSWORD);
 
     var hash = handler.getHash();
     var buffer = handler.createRequest();

--- a/test/unit/auth_handler_test.dart
+++ b/test/unit/auth_handler_test.dart
@@ -47,7 +47,7 @@ void main() {
       var username = 'Boris';
       var password = 'Password';
       var handler = AuthHandler(username, password, null, [1, 2, 3, 4],
-          clientFlags, maxPacketSize, characterSet, null);
+          clientFlags, maxPacketSize, characterSet, MYSQL_NATIVE_PASSWORD);
 
       var hash = handler.getHash();
       var buffer = handler.createRequest();
@@ -78,7 +78,7 @@ void main() {
           clientFlags,
           maxPacketSize,
           characterSet,
-          'mysql_native_password');
+          MYSQL_NATIVE_PASSWORD);
 
       var hash = handler.getHash();
       var buffer = handler.createRequest();

--- a/test/unit/handshake_handler_test.dart
+++ b/test/unit/handshake_handler_test.dart
@@ -359,7 +359,7 @@ void main() {
           serverCapabilities2,
           scrambleLength,
           scrambleBuffer2,
-          HandshakeHandler.MYSQL_NATIVE_PASSWORD,
+          MYSQL_NATIVE_PASSWORD,
           true);
       var response = handler.processResponse(responseBuffer);
 


### PR DESCRIPTION
This just needs some additions into auth handler.
* getHash: function modified to convert both native password and sha2 based password.
* Plugin name statics moved to handlers/handler.dart to beware using it recursively.
* Added a parameter for AuthHandler named `plugin`
