### PR TITLE
Export `TransactionContext`

### DIFF
--- a/lib/mysql1.dart
+++ b/lib/mysql1.dart
@@ -5,7 +5,7 @@ export 'src/mysql_client_error.dart' show MySqlClientError;
 export 'src/mysql_exception.dart' hide createMySqlException;
 export 'src/mysql_protocol_error.dart' hide createMySqlProtocolError;
 export 'src/single_connection.dart'
-    show MySqlConnection, Results, ConnectionSettings;
+    show MySqlConnection, TransactionContext, Results, ConnectionSettings;
 
 export 'src/auth/character_set.dart';
 


### PR DESCRIPTION
`TransactionContext` needs to be exported since the `transaction` method passes a `TransactionContext` to the `queryBlock` Function.