### PR TITLE
Fix `TransactionContext.query/queryMulti`

### DIFF
--- a/lib/src/single_connection.dart
+++ b/lib/src/single_connection.dart
@@ -224,11 +224,15 @@ class MySqlConnection {
 class TransactionContext {
   final MySqlConnection _conn;
   TransactionContext._(this._conn);
+  
+  MySqlConnection get connection => _conn;
 
-  Future<Results> query(String sql, [List<Object>? values]) =>
+  Future<Results> query(String sql, [List<Object?>? values]) =>
       _conn.query(sql, values);
-  Future<List<Results>> queryMulti(String sql, Iterable<List<Object>> values) =>
+  
+  Future<List<Results>> queryMulti(String sql, Iterable<List<Object?>> values) =>
       _conn.queryMulti(sql, values);
+  
   void rollback() => throw _RollbackError();
 }
 


### PR DESCRIPTION
To be compliant with `MySqlConnection.query/queryMulti` `TransactionContext.query/queryMulti` should have the same parameters signature.