### PR TITLE
Fix: The '?' is unnecessary because 'dynamic' is nullable without it.

### DIFF
--- a/lib/src/query/standard_data_packet.dart
+++ b/lib/src/query/standard_data_packet.dart
@@ -20,7 +20,7 @@ class StandardDataPacket extends ResultRow {
   final Map<String, dynamic> fields = <String, dynamic>{};
 
   StandardDataPacket(Buffer buffer, List<Field> fieldPackets) {
-    values = List<dynamic?>.filled(fieldPackets.length, null);
+    values = List<dynamic>.filled(fieldPackets.length, null);
     for (var i = 0; i < fieldPackets.length; i++) {
       var field = fieldPackets[i];
 


### PR DESCRIPTION
Fix Static Analysis: INFO: The '?' is unnecessary because 'dynamic' is nullable without it.